### PR TITLE
Add DICOM Seg option for MONAI Inference

### DIFF
--- a/monailabel/endpoints/infer.py
+++ b/monailabel/endpoints/infer.py
@@ -62,6 +62,7 @@ router = APIRouter(
                 },
                 "application/json": {"schema": {"type": "string", "example": "{}"}},
                 "application/octet-stream": {"schema": {"type": "string", "format": "binary"}},
+                "application/dicom": {"schema": {"type": "string", "format": "binary"}},
             },
         },
     },
@@ -177,7 +178,7 @@ def run_inference(
         image_uri = instance.datastore().get_image_uri(image)
         if not image_uri:
             raise HTTPException(status_code=500, detail="Image not found")
-        elif params == "{}":
+        elif p.get("label_info") is None:
             raise HTTPException(status_code=404, detail="Parameters for DICOM Seg inference cannot be empty!")
         # Transform image uri to id (similar to _to_id in local datastore)
         suffixes = [".nii", ".nii.gz", ".nrrd"]

--- a/monailabel/endpoints/infer.py
+++ b/monailabel/endpoints/infer.py
@@ -24,7 +24,7 @@ from fastapi.responses import FileResponse, Response
 from requests_toolbelt import MultipartEncoder
 
 from monailabel.config import RBAC_USER, settings
-from monailabel.datastore.utils.convert import binary_to_image
+from monailabel.datastore.utils.convert import binary_to_image, nifti_to_dicom_seg
 from monailabel.endpoints.user.auth import RBAC, User
 from monailabel.interfaces.app import MONAILabelApp
 from monailabel.interfaces.utils.app import app_instance
@@ -72,6 +72,7 @@ class ResultType(str, Enum):
     image = "image"
     json = "json"
     all = "all"
+    dicom_seg = "dicom_seg"
 
 
 def send_response(datastore, result, output, background_tasks):
@@ -92,6 +93,13 @@ def send_response(datastore, result, output, background_tasks):
 
     if output == "image":
         return FileResponse(res_img, media_type=m_type, filename=os.path.basename(res_img))
+
+    if output == "dicom_seg":
+        res_dicom_seg = result.get("dicom_seg")
+        if res_dicom_seg is None:
+            raise HTTPException(status_code=500, detail="Error processing inference")
+        else:
+            return FileResponse(res_dicom_seg, media_type="application/dicom", filename=os.path.basename(res_dicom_seg))
 
     res_fields = dict()
     res_fields["params"] = (None, json.dumps(res_json), "application/json")
@@ -162,6 +170,22 @@ def run_inference(
     result = instance.infer(request)
     if result is None:
         raise HTTPException(status_code=500, detail="Failed to execute infer")
+
+    # Dicom Seg Integration
+    if output == "dicom_seg" and image:
+        dicom_seg_file = None
+        image_uri = instance.datastore().get_image_uri(image)
+        if not image_uri:
+            raise HTTPException(status_code=500, detail="Image not found")
+        elif params == "{}":
+            raise HTTPException(status_code=404, detail="Parameters for DICOM Seg inference cannot be empty!")
+        # Transform image uri to id (similar to _to_id in local datastore)
+        suffixes = [".nii", ".nii.gz", ".nrrd"]
+        image_path = [image_uri.replace(suffix, "") for suffix in suffixes if image_uri.endswith(suffix)][0]
+        res_img = result.get("file") if result.get("file") else result.get("label")
+        dicom_seg_file = nifti_to_dicom_seg(image_path, res_img, p.get("label_info"), use_itk=True)
+        result["dicom_seg"] = dicom_seg_file
+
     return send_response(instance.datastore(), result, output, background_tasks)
 
 


### PR DESCRIPTION
## Context

Currently, in MONAI Label API Inference, and more concretely in a context of a DICOMWeb Datastore, the image inference results are only retrieved using the NIFTI format. However, when saving a label, it is possible to trigger MONAI Label to be able to store a DICOM Seg in the image archive using the dicom-web standard.

We at [BMDSoftware](https://github.com/BMDSoftware), find that could be useful to extend the use of the DICOM standard 
 to MONAI Label Inference, allowing to retrieve a DICOM Seg as result, avoiding this way the need for client applications to convert NIFTI image inference results to the standard DICOM format in the cases where the annotations/labels infered by MONAI Label are not to be saved immediatelly as final segmentations.

Since MONAI Label already has implemented conversions from NIFTI to DICOM Seg, this PR builts upon this to create DICOM Seg support in MONAI Label Inference.

## Summary

- Adds a new option in MONAI Label Inference API to return a DICOM Seg file.
- Uses existent conversions in MONAI Label to convert from NIFTI to DICOM Seg.